### PR TITLE
allowing to start babun from install script if

### DIFF
--- a/babun.bat
+++ b/babun.bat
@@ -51,6 +51,7 @@ IF '%1'=='/proxy' GOTO PROXY
 IF '%1'=='' (GOTO BEGIN) ELSE (GOTO BADSYNTAX)
 REM Done checking command line for switches
 GOTO BEGIN
+
 	:VERSION64
 	SET CYGWIN_VERSION=x86_64
 	SHIFT
@@ -94,6 +95,8 @@ GOTO BEGIN
 	
 	
 :BEGIN
+if exist %CYGWIN_HOME%\bin\mintty.exe goto RUN
+
 if %ERRORLEVEL% NEQ 0 (GOTO ERROR)	
 ECHO [babun] Installing babun version [%BABUN_VERSION%]
 
@@ -266,6 +269,9 @@ ECHO [babun] Creating desktop link
 cscript //Nologo "%LINKER%" "%USERPROFILE%\Desktop\babun.lnk" "%CYGWIN_HOME%\bin\mintty.exe" " - "
 if not exist "%USERPROFILE%\Desktop\babun.lnk" (GOTO ERROR)
 
+goto RUN
+
+:RUN
 ECHO [babun] Starting babun
 start %CYGWIN_HOME%\bin\mintty.exe - || goto :ERROR
 


### PR DESCRIPTION
once installed, babun should allow to start itself from the script (instead of executing install again) 
The final goal could be to start babun from cmd instead of desktop shortcut.

Maybe could babun check during installation if it can add itself to the classpath. Then one could start babun through start / cmd (like I do in most of the cases), or from existing cmd directly.
