### PR TITLE
Add a pause before EXIT on ERROR

### DIFF
--- a/babun-dist/install/install.bat
+++ b/babun-dist/install/install.bat
@@ -65,6 +65,7 @@ GOTO END
 
 :ERROR
 ECHO [babun] Terminating due to internal error #%errorlevel%
+pause
 EXIT /b %errorlevel%
 
 :END 


### PR DESCRIPTION
Add a pause so you can catch the error message if you ran install.bat via click rather than through shell.
https://github.com/babun/babun/issues/87
