### PR TITLE
Move console defaults to MinTTY config file.

### DIFF
--- a/babun-core/plugins/shell/src/minttyrc
+++ b/babun-core/plugins/shell/src/minttyrc
@@ -1,4 +1,7 @@
 BoldAsFont=no
+Columns=100
+Rows=35
+Font=Lucida Console
 FontHeight=10
 ForegroundColour=208,208,208
 BackgroundColour=28,28,28

--- a/babun-dist/start/babun.bat
+++ b/babun-dist/start/babun.bat
@@ -15,7 +15,7 @@ rem %BABUN_HOME%\fonts\RegisterFont.exe add "%BABUN_HOME%\fonts\Menlo\Menlo Bold
 
 ECHO [babun] Starting babun
 rem start %CYGWIN_HOME%\bin\mintty.exe --size 100,35 -o Font='Menlo Regular for Powerline' - || goto :ERROR
-start %CYGWIN_HOME%\bin\mintty.exe --size 100,35 -o Font='Lucida Console' - || goto :ERROR
+start %CYGWIN_HOME%\bin\mintty.exe - || goto :ERROR
 GOTO END
 
 :NOTFOUND


### PR DESCRIPTION
Addresses issue #86 by having the initial values in the `minttyrc` file instead of silently overriding the user's `.minttyrc` file on every new launch.
