### PR TITLE
hide scrollbar for mintty

### DIFF
--- a/babun-core/plugins/shell/src/minttyrc
+++ b/babun-core/plugins/shell/src/minttyrc
@@ -36,3 +36,4 @@ PgUpDnScroll=yes
 Term=xterm-256color
 CopyAsRTF=no
 RightClickAction=paste
+Scrollbar=none


### PR DESCRIPTION
hiding scrollbar by default in mintty so looks good when in full screen or using tmux.