### PR TITLE
Make sure to convert newlines before reading version file

### DIFF
--- a/babun-core/tools/check.sh
+++ b/babun-core/tools/check.sh
@@ -10,6 +10,7 @@ source "$babun_tools/script.sh"
 source "$babun_tools/stamps.sh"
 
 function get_current_version {
+	dos2unix $babun/installed/babun 2> /dev/null
 	local current_version=$( cat "$babun/installed/babun" 2> /dev/null || echo "0.0.0" )
 	echo "$current_version"
 }


### PR DESCRIPTION
This fix uses the problems mentioned here #170.
The only thing I am not sure about is whether dos2unix is installed in babun.
