### PR TITLE
gettext is required for git submodule to function properly

### DIFF
--- a/babun-packages/conf/cygwin.x86.packages
+++ b/babun-packages/conf/cygwin.x86.packages
@@ -23,6 +23,7 @@ findutils
 gawk
 gcc
 gcc-core
+gettext
 git
 git-svn
 gnutls


### PR DESCRIPTION
git submodule doesn't work until gettext is installed