### PR TITLE
Change _faq.adoc for ConEmu integration

### DIFF
--- a/babun-doc/adoc/_faq.adoc
+++ b/babun-doc/adoc/_faq.adoc
@@ -67,8 +67,8 @@ Also, have a look at this https://github.com/babun/babun/issues/143[thread].
 * In ConEmu
 ** Go to Settings>Startup>Tasks
 ** Create a new task
-*** Task parameters - /icon "%userprofile%.babun\cygwin\bin\mintty.exe" /dir "%userprofile%"
-*** Commands %userprofile%.babun\cygwin\bin\mintty.exe -
+*** Task parameters - /icon "%userprofile%\.babun\cygwin\bin\mintty.exe" /dir "%userprofile%"
+*** Commands %userprofile%\.babun\cygwin\bin\mintty.exe -
 
 Babun is available in the "Create new console" menu.
 


### PR DESCRIPTION
When launching the described setup for ConEmu in the FAQs the %userprofile% var and .babun are concatenated and the folder is not found. A backslash needs to be added such that the path is correct and Babun is launched properly.
## _faq.adoc

```
*** Task parameters - /icon "%userprofile%.babun\cygwin\bin\mintty.exe" /dir "%userprofile%"
*** Commands %userprofile%.babun\cygwin\bin\mintty.exe -
```

should be...

```
*** Task parameters - /icon "%userprofile%\.babun\cygwin\bin\mintty.exe" /dir "%userprofile%"
*** Commands %userprofile%\.babun\cygwin\bin\mintty.exe -
```
