### PR TITLE
Fix core plugins count in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ Babun provides many packages, convenience tools and scripts that make your life 
 
 ==== Plugin architecture
 
-Babun has a very small microkernel (cygwin, a couple of bash scripts and a bit of a convention) and a plugin architecture on the top of it. It means that almost everything is a plugin in the babun's world! Not only does it structure babun in a clean way, but also enables others to contribute small chunks of code. Currently, babun comprises six plugins:
+Babun has a very small microkernel (cygwin, a couple of bash scripts and a bit of a convention) and a plugin architecture on the top of it. It means that almost everything is a plugin in the babun's world! Not only does it structure babun in a clean way, but also enables others to contribute small chunks of code. Currently, babun comprises the following plugins:
 
 * cacert
 * core


### PR DESCRIPTION
At the time of writing, this line says there are 6 plugins, but the list immediately following actually contains 8 items.

Might be best to just not mention the count of babun's core plugins, so this doesn't have the possibility of getting out of sync.
