### PR TITLE
Ensure setting of BABUN_HOME and CYGWIN_HOME

### DIFF
--- a/babun-core/plugins/core/src/babun.rc
+++ b/babun-core/plugins/core/src/babun.rc
@@ -7,6 +7,8 @@ source "/usr/local/etc/babun.instance"
 export CYGWIN_VERSION=x86
 export CYGWIN="nodosfilewarning mintty"
 export TERM=xterm-256color
+export CYGWIN_HOME=`/usr/bin/cygpath.exe -ma "/"`
+export BABUN_HOME=`echo $CYGWIN_HOME | /usr/bin/sed.exe "s#/cygwin##g"`
 
 alias ls='ls --color=auto'
 alias grep='grep --color=auto'


### PR DESCRIPTION
If babun wasn't started via babun.bat those two important environment
variables were missing.
Now they get set every time a shell gets started and so
they are set even if you start mintty.exe directly.

Closes Issue #298