### PR TITLE
Update compdef/compinit faq to use $ZSH_VERSION

### DIFF
--- a/babun-doc/adoc/_faq.adoc
+++ b/babun-doc/adoc/_faq.adoc
@@ -170,7 +170,7 @@ Execute:
 
 ----
 $ compinit
-$ cp .zcompdump .zcompdump-$HOSTNAME-5.0.2
+$ cp .zcompdump .zcompdump-$HOSTNAME-$ZSH_VERSION
 ----
 
 == ps option -U and -o unknown


### PR DESCRIPTION
FAQ has a hardcoded ZSH Version string, which isn't really useful for
future proofing. Especially as this issue seems to crop up repeatedly
through history, this will at least make sure when people are copy paste
fixing they get the right file output.