### PR TITLE
"/etc/vimrc" Relaxed about "ir_black" Colorscheme, Fixing #365.

### DIFF
--- a/babun-core/plugins/shell/plugin.desc
+++ b/babun-core/plugins/shell/plugin.desc
@@ -1,3 +1,3 @@
 # plugin descriptor
 plugin_name=shell
-plugin_version=2
+plugin_version=3

--- a/babun-core/plugins/shell/src/vimrc
+++ b/babun-core/plugins/shell/src/vimrc
@@ -91,5 +91,5 @@ endif
 " SYNTAX HIGHLIGHTING:
 set t_Co=256
 syntax on
-colorscheme ir_black
+silent! colorscheme ir_black
 set bs=2


### PR DESCRIPTION
`/etc/vimrc` now silently ignores the absence of the `ir_black` colorscheme rather than vomiting up a non-fatal warning requiring _\<Enter\>_ be pressed on *every* Vim startup. To apply this clearly critical fix (_\</sarcasm\>_) on the next Babun update, the `shell` plugin version has been incremented as well.

This fixes issue #365 in entirety and the only meaningful portion of issue #344. For unsavoury (and possibly illicit) details, see the dark recesses of #365.

_**P.S.** Thanks for all the rockin' suavity, Babun and crew._ :microphone: 