### PR TITLE
Fix odd file perms issue with symlinked .gitconfig

### DIFF
--- a/babun-core/tools/git.sh
+++ b/babun-core/tools/git.sh
@@ -13,4 +13,7 @@ else
 	fi
 fi
 
-git config --global core.trustctime false
+trustctime=$(git config --global core.trustctime || echo "")
+if [[ "$trustctime" != "false" ]]; then
+	git config --global core.trustctime false
+fi


### PR DESCRIPTION
I received this error when starting up babun after a recent update
```
error: chmod on /cygdrive/e/Jordan/Code/git/dotfiles/gitconfig.lock failed: Permission denied
Error on or near line 16, last command 'trap 'catch_err "${previous_command}" ${LINENO}' ERR';
Error on or near line 4, last command 'source "$babun_tools/git.sh"';
Could not start plugin [git]
```
This fixes it by only trying to set trustctime if it needs to be. I symlink my config into my dotfiles git repository so I can easily sync config between different environments, and this revealed this issue.