### PR TITLE
Anaconda Integration

### DIFF
--- a/babun-core/plugins/conda/install.sh
+++ b/babun-core/plugins/conda/install.sh
@@ -1,0 +1,5 @@
+set -e -f -o pipefail
+source "/usr/local/etc/babun.instance"
+source "$babun_tools/script.sh"
+
+# NO LOGIC

--- a/babun-core/plugins/conda/install_home.sh
+++ b/babun-core/plugins/conda/install_home.sh
@@ -1,0 +1,5 @@
+set -e -f -o pipefail
+source "/usr/local/etc/babun.instance"
+source "$babun_tools/script.sh"
+
+# NO LOGIC

--- a/babun-core/plugins/conda/plugin.desc
+++ b/babun-core/plugins/conda/plugin.desc
@@ -1,0 +1,3 @@
+# plugin descriptor
+plugin_name=conda
+plugin_version=1

--- a/babun-core/plugins/conda/start_sourced.sh
+++ b/babun-core/plugins/conda/start_sourced.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# If prioritizing Anaconda and Miniconda over pact, shift all Anaconda and
+# Miniconda directories in the current ${PATH} to the head of that list while
+# preserving the ordering of all other listed directories. This modifies the
+# current shell environment and hence *MUST* be sourced in the current shell
+# process rather than run in a new bash process (as "start.sh" is).
+if [[ "$PRIORITIZE_CONDA_PACKAGES" == true ]]; then
+    # To permit the ${IFS} global to be shadowed by a local variable of the same
+    # name, this logic is segregated to a temporary function.
+    function _prioritize_conda_packages() {
+        # If the current shell is bash rather than zsh, define a ${path} list of
+        # all paths split from the current colon-delimited ${PATH}. Note that
+        # Zsh already defines this list as a global of the same name.
+        if [[ -n "${BASH_VERSION:+x}" ]]; then
+            # Temporarily disable filename globbing for the duration of this call,
+            # preventing expansion of glob-reserved characters (e.g., "*", "?") in
+            # filenames parsed below.
+            set -f
+
+            # Split shell words on colons. To avoid modifying the ${IFS} global, a
+            # local variable of the same name is modified instead.
+            local IFS=':'
+
+            # List of all paths split from the current colon-delimited ${PATH}. Note
+            # that ${PATH} must *NOT* be double-quoted here.
+            local -a path; path=( $PATH )
+
+            # Reenable filename globbing.
+            set +f
+        fi
+
+        # Split this list into two lists: one containing only Anaconda and
+        # Miniconda directories and the other containing all other directories.
+        local -a conda_paths nonconda_paths
+        local cur_path
+        for   cur_path in "${path[@]}"; do
+            # For portability both between shells and regex libraries:
+            #
+            # * This regex is unquoted. While zsh transparently supports both
+            #   quoted and unquoted regexes, bash supports only the latter.
+            #   Since regex syntax often conflicts with shell syntax and hence
+            #   must be explicitly escaped to be used in an unquoted manner,
+            #   this was (arguably) a poor design decision on bash's part.
+            # * Character classes in this regex are manually defined rather than
+            #   predefined (e.g., "[0-9]" rather than "\d"). Oddly, the latter
+            #   appear to be unrecognized under oh-my-zsh.
+            if [[ "$cur_path" =~ ^(/cygdrive)?/[a-z]/(Ana|Mini)conda[0-9]?(/.*)?$ ]]; then
+                conda_paths+=( "$cur_path" )
+            else
+                nonconda_paths+=( "$cur_path" )
+            fi
+        done
+
+        # Reconstitute the list of all paths from these lists.
+        path=( "${conda_paths[@]}" "${nonconda_paths[@]}" )
+
+        # If the current shell is bash rather than zsh, reconstitute the current
+        # colon-delimited ${PATH} from the ${path} list. Due to the above ${IFS}
+        # change, this implicitly joins the latter list on ":" into a string
+        # scalar then assigned to ${PATH}.
+        if [[ -n "${BASH_VERSION:+x}" ]]; then
+            PATH="${path[*]}"
+        fi
+    }
+
+    # Perform such logic.
+    _prioritize_conda_packages
+
+    # Undefine our temporary function.
+    unset -f _prioritize_conda_packages
+fi

--- a/babun-core/plugins/core/plugin.desc
+++ b/babun-core/plugins/core/plugin.desc
@@ -1,3 +1,3 @@
 # plugin descriptor
 plugin_name=core
-plugin_version=4
+plugin_version=5

--- a/babun-core/plugins/core/src/.babunrc
+++ b/babun-core/plugins/core/src/.babunrc
@@ -32,3 +32,8 @@ export LC_ALL="en_US.UTF-8"
 
 # Uncomment to enable bloda detection
 # export CYGWIN="nodosfilewarning mintty detect_bloda"
+
+# Uncomment to prioritize Anaconda- and Miniconda-installed packages (e.g.,
+# "/cygdrive/c/Miniconda3/python") over pact-installed packages (e.g.,
+# "/usr/bin/python"). By default, the latter takes priority over the former.
+# export PRIORITIZE_CONDA_PACKAGES="true"

--- a/babun-core/plugins/core/src/babun.rc
+++ b/babun-core/plugins/core/src/babun.rc
@@ -39,6 +39,7 @@ export LC_ALL="en_US.UTF-8"
 
 export DISABLE_CHECK_ON_STARTUP="false"
 export CHECK_TIMEOUT_IN_SECS=4
+export PRIORITIZE_CONDA_PACKAGES="false"
 
 # otherwise vim will not find /etc/vimrc
 export VIM=/etc

--- a/babun-core/plugins/core/src/babun.start
+++ b/babun-core/plugins/core/src/babun.start
@@ -1,6 +1,10 @@
 #!/bin/bash
 source "/usr/local/etc/babun.instance"
 
+# Source plugins modifying the current shell process *BEFORE* running plugins
+# in a new bash process. (The latter inherit the modifications of the former.)
+source "$babun_plugins/start_sourced.sh"
+
 "$babun_plugins/start.sh"
 "$babun_tools/welcome.sh"
 

--- a/babun-core/plugins/oh-my-zsh/install.sh
+++ b/babun-core/plugins/oh-my-zsh/install.sh
@@ -19,7 +19,14 @@ if [ ! -d "$dest" ]; then
 	mkdir -p "$dest"
     /bin/cp -rf "$src/." "$dest"
     /bin/cp "$dest/templates/zshrc.zsh-template" "$babun/home/.zshrc"
-    /bin/sed -i 's/ZSH_THEME=".*"/ZSH_THEME="babun"/' "$babun/home/.zshrc"
     /bin/cp -rf "$babun_source/babun-core/plugins/oh-my-zsh/src/babun.zsh-theme" "$dest/custom"
+
+    # Set the default oh-my-zsh theme to the Babun theme installed above.
+    /bin/sed -i 's/ZSH_THEME=".*"/ZSH_THEME="babun"/' "$babun/home/.zshrc"
+
+    # Avoid prepending the ${PATH} with "/usr/local/bin". Doing so conflicts
+    # with plugins also prepending the ${PATH} (e.g., "conda") and is redundant
+    # (as "/usr/local/bin" already heads the ${PATH} by default).
+    /bin/sed -i '/^export PATH=/s~/usr/local/bin:~~' "$babun/home/.zshrc"
 fi
 

--- a/babun-core/plugins/oh-my-zsh/plugin.desc
+++ b/babun-core/plugins/oh-my-zsh/plugin.desc
@@ -1,3 +1,3 @@
 # plugin descriptor
 plugin_name=oh-my-zsh
-plugin_version=2
+plugin_version=3

--- a/babun-core/plugins/start_sourced.sh
+++ b/babun-core/plugins/start_sourced.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Source the passed plugin's "start_sourced.sh" script in the current shell
+# process. By definition, this is less safe than running that plugin's
+# "start.sh" script in a new bash process and hence should be used only where
+# needed (e.g., to modify the current shell's ${PATH}).
+#
+# This function is defined here rather than in "tools/plugins.sh", the customary
+# script for plugin-specific utility functions, to avoid polluting the current
+# shell with extraneous functions.
+function _plugin_start_sourced {
+	local plugin_name="$1"
+	local start_sourced_script="$babun_plugins/$plugin_name/start_sourced.sh"
+
+	if [[ -f "$start_sourced_script" ]]; then
+        source "$start_sourced_script" ||
+            echo "Could not start sourced plugin [$plugin_name]" 1>&2
+    else
+		echo "ERROR: Cannot find plugin start_sourced.sh script [$plugin_name] [$start_sourced_script]" 1>&2
+	fi 
+}
+
+# Start all plugins modifying the current shell process.
+_plugin_start_sourced "conda"
+
+# Undefine our utility function.
+unset -f _plugin_start_sourced


### PR DESCRIPTION
This pull request improves integration with both [Anaconda](http://continuum.io/downloads) and its anorexic sibling [Miniconda](http://conda.pydata.org/miniconda.html), fixing #377 and making Babun Python users squeal with kiddish glee. (_You're out there. **I know you are.**_)

## What's the Problem, Bro?

Read issue #377 first, bro. High-level synopsis **+** fuzzy details **=** gotcha moment.

## No, Really. What's the Problem?

`pact`-installed packages take precedence over `conda`-installed packages under Babun's default `bash` and `oh-my-zsh` environments. That's a problem, effectively nullifying Anaconda and Miniconda out of the box.

## So. Like, What's Your Solution?

First, a real-world example. The `pact`-managed path `/usr/bin` precedes the `conda`-managed path `/cygdrive/c/Miniconda3` under default installations of both Babun and Miniconda3:

    { ~ }  » print -l $path
    /home/Administrator/bin
    /usr/local/bin
    /usr/local/bin
    /usr/bin
    /cygdrive/c/WINDOWS/system32
    /cygdrive/c/WINDOWS
    /cygdrive/c/WINDOWS/System32/Wbem
    /cygdrive/c/Miniconda3
    /cygdrive/c/Miniconda3/Scripts
    /cygdrive/c/babun/.babun
    /cygdrive/c/Documents and Settings/Administrator/.babun

Ideally, Miniconda3 users want that to instead resemble:

    { ~ }  » print -l $path
    /cygdrive/c/Miniconda3
    /cygdrive/c/Miniconda3/Scripts
    /home/Administrator/bin
    /usr/local/bin
    /usr/local/bin
    /usr/bin
    /cygdrive/c/WINDOWS/system32
    /cygdrive/c/WINDOWS
    /cygdrive/c/WINDOWS/System32/Wbem
    /cygdrive/c/babun/.babun
    /cygdrive/c/Documents and Settings/Administrator/.babun

To effect that, this pull request adds a new user-configurable `${PRIORITIZE_CONDA_PACKAGES}` boolean. When manually uncommented in `~/.babunrc`, this boolean instructs Babun startup to juggle the `${PATH}` such that `conda`-installed packages take precedence over `pact`-installed packages. For end user sanity, this boolean is disabled by default in `/usr/local/etc/babun.rc`. For portability, this boolean has been implemented at the plugin level and exhaustively tested as working under both `bash` and `oh-my-zsh`.

## What Could Possibly Go Wrong?

Plenty:

1. **`bash` has no analogue to `zsh`'s standard `${path}` list.** `zsh` implicitly splits the colon-delimited `${PATH}` string into the `${path}` list, each item of which is a directory in `${PATH}` (in the same order). Changes to one are immediately reflected in the other, trivializing `${PATH}` juggling. `bash` has *nothing* like that. In `bash`, `${PATH}` juggling requires:
   1. Manually splitting `${PATH}` on colons into a `${path}`-like list. (Hint: it sucks.)
   1. Juggling that list.
   1. Manually joining that list on colons back into `${PATH}`. (Yup! This sucks, too.)
1. **`oh-my-zsh`'s default `~/.zshrc` prepends `${PATH}` with `/usr/local/bin` _after_ all Babun startup scripts and plugins have been run.** Like `/usr/bin`, `/usr/local/bin` is a `pact`-managed path containing copies of `pact`-installed packages – including `python`. Since this happens *after* Babun has had its say, the default `~/.zshrc` overrides any attempt by Babun to prepend `${PATH}` with a `conda`-managed path containing `conda`-installed packages – again, including `python`. (This is me ineffectually shaking my broken keyboard at the sky.) 
1. **Babun prohibits plugins from modifying the current shell environment.** For safety, each Babun plugin is isolated to a separate `bash` process forked specifically for that plugin. That's *usually* what we want. We don't want plugins of dubious reliability taking down the entire Babun startup (e.g., due to some external command returning non-zero exit status under `set -e` strictness). That would be terrible, right? On occasion, however, we *do* actually need to source a plugin in the current shell process – and we swear we'll be careful about it! This is that occasion.

We've already addressed how we perform `${PATH}` juggling in `bash`. It's not pretty, but it works. Let's address the latter two.

### Default `.zshrc`

It's critical that Babun be able to safely modify `${PATH}`, both for this pull request *and* any future plugins requiring such modification. Babun shouldn't have to worry about the default `~/.zshrc` maliciously undo-ing its hard work.

Here's what the default `~/.zshrc` does:

    export PATH=$HOME/bin:/usr/local/bin:$PATH

**Prepending `${PATH}` by `/usr/local/bin` here is pointless.** As examples above illustrate, Babun *already* prepends `${PATH}` by `/usr/local/bin`. Why do it twice? Don't! So, the prior statement is reducible without loss of generality to: 

    export PATH=$HOME/bin:$PATH

This pull request patches the latter statement into the default `~/.zshrc` on installation. (O.K., technically `/usr/local/etc/babun/home/.zshrc` is patched on installation. But you know what we mean, man.)  Since the default `~/.bashrc` suffers no similar issue, we're done here.

## Plugin Isolation

While Babun plugins cannot modify the current shell environment, Babun *does* provides two shell scripts commonly sourced on both `bash` and `zsh` startup:

* `/usr/local/etc/babun.rc`, which is sourced *before* `~/.babunrc`, which optionally redefines the `${PRIORITIZE_CONDA_PACKAGES}` boolean upon which our `${PATH}` juggling depends. It follows that `/usr/local/etc/babun.rc` cannot perform such juggling. (*Q.E.D., and stuff.*)
* `/usr/local/etc/babun.start`, a high-level wrapper around the `babun-core/plugins/start.sh` and `babun-core/tools/welcome.sh` scripts. Technically, our `${PATH}` juggling *could* be embedded directly into this wrapper. Doing so would probably establish a bad precedent, however. **It's a high-level wrapper.** It's *not* supposed to contain low-level logic specific to optional external commands. Plugins exist for a reason. This is it.

Since `babun.rc` is right out and `babun.start` should be, we're at an impasse. I'd hope we could all agree, though, that plugins *should* be able to modify the current shell environment when there absolutely exists no other way. (Let's just pretend we agree.) Under that assumption, this pull request adds support for a new type of plugin-specific script: `start_sourced.sh`.

Like `start.sh` scripts, `start_sourced.sh` scripts are run at Babun startup. Unlike `start.sh` scripts, `start_sourced.sh` scripts are sourced in the current shell process rather than run in a separate `bash` process. Simple, right?

## The End, My Friend

Let's put it all together. Since plugins can now modify the current shell environment, we define a new `conda` plugin whose `start_sourced.sh` script tests whether the `${PRIORITIZE_CONDA_PACKAGES}` boolean is `true` and, if so:

1. Iteratively searches the `${PATH}` for all Anaconda and Miniconda directories.
1. Moves all such directories to the front of `${PATH}` in an order-preserving manner (i.e., preserving the internal order of all such directories *and* all other directories in `${PATH}`).

**Yeah.**