### PR TITLE
Add parameters to babun.bat and improve shell-here integration

### DIFF
--- a/babun-core/plugins/shell-here/exec.sh
+++ b/babun-core/plugins/shell-here/exec.sh
@@ -5,6 +5,7 @@ function set_reg_keys {
 
 	local babun_root="$( cygpath -w "/" | sed "s#\\\cygwin##g" )"
 	# the name that appears in the right-click context menu
+	local icon="${babun_root}\cygwin\bin\mintty.exe"
 	local name="Open in Babun"
 	local background_name="Open Babun here"
 	local cmd="${babun_root}\babun.bat \"%1\""
@@ -17,13 +18,15 @@ function set_reg_keys {
 
 	#install registry keys
 	for key in ${keys[*]}
-	do 
+	do
 		cmd /c "reg" "add" "${key}" "/ve" "/d" "${name}" "/t" "REG_SZ" "/f" || echo "Failed adding ${key}"
+		cmd /c "reg" "add" "${key}" "/v" "Icon" "/d" "${icon}" "/t" "REG_SZ" "/f" || echo "Failed adding ${key}"
 		cmd /c "reg" "add" "${key}\command" "/ve" "/d" "${cmd}" "/t" "REG_EXPAND_SZ" "/f" || echo "Failed adding ${key}"
 	done
 	for key in ${background_keys[*]}
 	do
 		cmd /c "reg" "add" "${key}" "/ve" "/d" "${background_name}" "/t" "REG_SZ" "/f" || echo "Failed adding ${key}"
+		cmd /c "reg" "add" "${key}" "/v" "Icon" "/d" "${icon}" "/t" "REG_SZ" "/f" || echo "Failed adding ${key}"
 		cmd /c "reg" "add" "${key}\command" "/ve" "/d" "${background_cmd}" "/t" "REG_EXPAND_SZ" "/f" || echo "Failed adding ${key}"
 	done
 }
@@ -37,7 +40,7 @@ function unset_reg_keys {
 
 	#uninstall registry keys
 	for key in ${keys[*]}
-	do 
+	do
 		cmd /c "reg" "delete" "${key}" "/f" || echo "Failed deleting ${key}"
 	done
 
@@ -50,6 +53,6 @@ elif [ "$1" == "remove" ]; then
 	unset_reg_keys
 elif [ "$1" == "" ]; then
 	echo "Missing argument. Use 'init' or 'remove' option."
-else 
+else
 	echo "Invalid option $1. Valid options are 'init' and 'remove'."
 fi

--- a/babun-core/plugins/shell-here/exec.sh
+++ b/babun-core/plugins/shell-here/exec.sh
@@ -5,13 +5,15 @@ function set_reg_keys {
 
 	local babun_root="$( cygpath -w "/" | sed "s#\\\cygwin##g" )"
 	# the name that appears in the right-click context menu
-	local name="Open Babun here"
-	local cmd="${babun_root}\cygwin\bin\mintty.exe /bin/env CHERE_INVOKING=1 /bin/zsh.exe"
+	local name="Open in Babun"
+	local background_name="Open Babun here"
+	local cmd="${babun_root}\babun.bat \"%1\""
+	local background_cmd="${babun_root}\babun.bat \"%V\""
 
-	local keys=("HKCU\Software\Classes\Directory\Background\shell\babun"
-	"HKCU\Software\Classes\Directory\shell\babun"
-	"HKCU\Software\Classes\Drive\Background\Shell\babun"
+	local keys=("HKCU\Software\Classes\Directory\shell\babun"
 	"HKCU\Software\Classes\Drive\shell\babun")
+	local background_keys=("HKCU\Software\Classes\Directory\Background\shell\babun"
+	"HKCU\Software\Classes\Drive\Background\Shell\babun")
 
 	#install registry keys
 	for key in ${keys[*]}
@@ -19,7 +21,11 @@ function set_reg_keys {
 		cmd /c "reg" "add" "${key}" "/ve" "/d" "${name}" "/t" "REG_SZ" "/f" || echo "Failed adding ${key}"
 		cmd /c "reg" "add" "${key}\command" "/ve" "/d" "${cmd}" "/t" "REG_EXPAND_SZ" "/f" || echo "Failed adding ${key}"
 	done
-
+	for key in ${background_keys[*]}
+	do
+		cmd /c "reg" "add" "${key}" "/ve" "/d" "${background_name}" "/t" "REG_SZ" "/f" || echo "Failed adding ${key}"
+		cmd /c "reg" "add" "${key}\command" "/ve" "/d" "${background_cmd}" "/t" "REG_EXPAND_SZ" "/f" || echo "Failed adding ${key}"
+	done
 }
 
 function unset_reg_keys {
@@ -29,7 +35,7 @@ function unset_reg_keys {
 	"HKCU\Software\Classes\Drive\Background\Shell\babun"
 	"HKCU\Software\Classes\Drive\shell\babun")
 
-	#install registry keys
+	#uninstall registry keys
 	for key in ${keys[*]}
 	do 
 		cmd /c "reg" "delete" "${key}" "/f" || echo "Failed deleting ${key}"

--- a/babun-dist/start/babun.bat
+++ b/babun-dist/start/babun.bat
@@ -5,15 +5,51 @@ set SCRIPT_PATH=%~dp0
 set SCRIPT_PATH=%SCRIPT_PATH:\=/%
 set BABUN_HOME=%SCRIPT_PATH%
 
+
 :BEGIN
-set CYGWIN_HOME=%BABUN_HOME%\cygwin
-if exist "%CYGWIN_HOME%\bin\mintty.exe" goto RUN
-if not exist "%CYGWIN_HOME%\bin\mintty.exe" goto NOTFOUND
+set CYGWIN_HOME=%BABUN_HOME%cygwin
+IF not exist "%CYGWIN_HOME%\bin\mintty.exe" GOTO :NOTFOUND
+
+:PARSEPARAMS
+IF "%~1"=="" (
+    GOTO :RUN
+)
+IF "%~1"=="--help" (
+    GOTO :HELP
+)
+IF "%~1"=="-run" (
+    set _params=%~2
+    SHIFT
+    SHIFT
+    GOTO :PARSEPARAMS
+)
+set CHERE_INVOKING=1
+IF "%~1"=="--here" (
+    SHIFT
+    GOTO :PARSEPARAMS
+)
+:: ELSE
+if NOT "%_path%"=="" (
+    ECHO Only one path may be specified!
+    GOTO :END
+)
+cd /d %1
+set %_path%=%1
+SHIFT
+GOTO :PARSEPARAMS
+
 
 :RUN
 ECHO [babun] Starting babun
-start "" "%CYGWIN_HOME%\bin\mintty.exe" - || goto :ERROR
-GOTO END
+IF NOT "%CHERE_INVOKING%"=="" (
+    ECHO [babun] in: %cd%
+)
+IF NOT "%_params%"=="" (
+    ECHO [babun] with parameters: %_params%
+)
+start "" "%CYGWIN_HOME%\bin\mintty.exe" %_params% || GOTO :ERROR
+GOTO :END
+
 
 :NOTFOUND
 ECHO [babun] Start script not found. Babun installation seems to be corrupted.
@@ -22,5 +58,21 @@ EXIT /b 255
 :ERROR
 ECHO [babun] Terminating due to internal error #%errorlevel%
 EXIT /b %errorlevel%
+
+:HELP
+ECHO usage: babun.bat [--help] [--here] [-run=^<command^>] [^<path^>]
+ECHO Open the babun shell (mintty).
+ECHO.
+ECHO Parameters:
+ECHO    --help
+ECHO        Show this help message.
+ECHO    --here
+ECHO        Open shell in the current working directory.
+ECHO    -run=^<command^>
+ECHO        Run mintty with the arguments in command.
+ECHO    ^<path^>
+ECHO        Open shell in the specified directory.
+ECHO        Overrides --here. May only occur once.
+ECHO.
 
 :END


### PR DESCRIPTION
### What I wanted
1. Ability to launch babun via normal methods (e.g. desktop shortcut) and open it in `~`.
2. Ability to launch babun via external executables, such as from within cmd prompt or Total Commander. This is incredibly useful when %babun_home% is in %path%.
3. Ability to launch babun in an arbitrary folder.

While doing this, I though it would be neat to be able to pass command arguments to mintty, so I added that as well.
### Solution

Parse parameters in `babun.bat`.
Supported are --help, --here, -run "command" and "path". Details in commit.

Note that I had to remove the '-' parameter from calling mintty because it prevented CHERE_INVOKING being interpreted for some reason. There shouldn't be any changes in functionality as far as I can tell.
#### Followup Fix

The context menu item installed from the "shell-here" plugin can now use babun.bat to properly forward the `%` parameters it receives. #390 should be fixed by this, but I'm not sure I fully understood the issue.

Note that I haven't been able to get the Drive/Background prompt. If anyone has an idea when this is called, please report back.
### Demonstration

Have a screencast of me opening the babun shell in several ways (url potentially not permanent):

http://fichtefoll.taiga-san.net/screencasts/2015-07-17_1955_babun.swf

(`C:\Users\Fichte\.babun` is on my PATH)
## 

**Important Note**: The execution of `babun-core/plugins/shell-here/exec.sh` has not been tested (because I don't know how), but the values I intend to set have. Please review carefully.

References https://github.com/babun/babun/pull/293, https://github.com/babun/babun/issues/183
