### PR TITLE
Remove duplicate property CHECK_TIMEOUT_IN_SECS.

### DIFF
--- a/babun-core/plugins/core/src/.babunrc
+++ b/babun-core/plugins/core/src/.babunrc
@@ -14,9 +14,6 @@ export LC_ALL="en_US.UTF-8"
 # Uncomment this to disable daily auto-update & proxy checks on startup (not recommended!)
 # export DISABLE_CHECK_ON_STARTUP="true"
 
-# Uncomment to increase/decrease the check connection timeout
-# export CHECK_TIMEOUT_IN_SECS=4
-
 # Uncomment this lines to set up your proxy
 # export http_proxy=http://user:password@server:port
 # export https_proxy=$http_proxy


### PR DESCRIPTION
The file .babunrc has a duplicate entry for the variable CHECK_TIMEOUT_IN_SECS.

This little pull request was created on Hacker Garten Berne to fix the issue.