### PR TITLE
Removing double space from prompt

### DIFF
--- a/babun-core/plugins/oh-my-zsh/src/babun.zsh-theme
+++ b/babun-core/plugins/oh-my-zsh/src/babun.zsh-theme
@@ -1,7 +1,7 @@
 local return_code="%(?..%{$fg[red]%}%? %{$reset_color%})"
 
 PROMPT='%{$fg[blue]%}{ %c } \
-%{$fg[green]%}$(  git rev-parse --abbrev-ref HEAD 2> /dev/null || echo ""  )%{$reset_color%} \
+%{$fg[green]%}$(  git rev-parse --abbrev-ref HEAD 2> /dev/null || echo "\b"  )%{$reset_color%} \
 %{$fg[red]%}%(!.#.»)%{$reset_color%} '
 
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'


### PR DESCRIPTION
Hi
I have a small life quality change request:
Removing double space from prompt when not in git repository.
This shouldn't drive me mad as much as it does... but it does.
Tested on windows and Ubuntu 14.04 with no noticeable errors. 