### PR TITLE
Updated PACT to remove a downloaded file when checksums don't match

### DIFF
--- a/babun-core/plugins/pact/src/pact
+++ b/babun-core/plugins/pact/src/pact
@@ -232,6 +232,7 @@ function installPkg()
       if ! [[ $digest == $shadigactual ]]
       then
         echo Verification hash did not match, exiting
+        rm $file # Remove the file with bad checksum
         exit 1
       fi
     fi


### PR DESCRIPTION
Updated PACT to remove a downloaded file when checksums don't match, this was
causing me an issue with files that downloaded halfway