### PR TITLE
Let shell-here plugin use user defined default shell

### DIFF
--- a/babun-core/plugins/shell-here/exec.sh
+++ b/babun-core/plugins/shell-here/exec.sh
@@ -6,7 +6,7 @@ function set_reg_keys {
 	local babun_root="$( cygpath -w "/" | sed "s#\\\cygwin##g" )"
 	# the name that appears in the right-click context menu
 	local name="Open Babun here"
-	local cmd="${babun_root}\cygwin\bin\mintty.exe /bin/env CHERE_INVOKING=1 /bin/zsh.exe"
+	local cmd="${babun_root}\cygwin\bin\mintty.exe"
 
 	local keys=("HKCU\Software\Classes\Directory\Background\shell\babun"
 	"HKCU\Software\Classes\Directory\shell\babun"


### PR DESCRIPTION
As described in #410 this plugin will open zsh, regardless of which default shell the user has set.

As far as I have tested removing "/bin/env" part of original command has no impact on the shell session - result of running `env` in the session opened by shell-here has no difference than one in session opened by double clicking desktop icon, except the "CHERE_INVOKING=1" flag set by the original command.