### PR TITLE
Fix shell-here plugin (fixes #410, #451 and #590)

### DIFF
--- a/babun-core/plugins/core/src/babun.rc
+++ b/babun-core/plugins/core/src/babun.rc
@@ -69,6 +69,12 @@ fi
 
 PATH="$HOME_LOCAL_BIN:$PATH"
 
+# shell-here
+if [ ! -z "$INVOKE_CD" ] ; then
+    cd "$INVOKE_CD"
+    unset INVOKE_CD
+fi
+
 #
 # IMPORTANT -> THIS HAS TO BE LOCATED AT THE END OF THIS SCRIPT
 # install babun to user's home folder if it does not exist

--- a/babun-core/plugins/shell-here/exec.sh
+++ b/babun-core/plugins/shell-here/exec.sh
@@ -6,7 +6,7 @@ function set_reg_keys {
 	local babun_root="$( cygpath -w "/" | sed "s#\\\cygwin##g" )"
 	# the name that appears in the right-click context menu
 	local name="Open Babun here"
-	local cmd="${babun_root}\cygwin\bin\mintty.exe /bin/env CHERE_INVOKING=1 /bin/zsh.exe"
+	local cmd="${babun_root}\cygwin\bin\mintty.exe /bin/env CHERE_INVOKING=1 INVOKE_CD=\"%V\" ${SHELL}"
 
 	local keys=("HKCU\Software\Classes\Directory\Background\shell\babun"
 	"HKCU\Software\Classes\Directory\shell\babun"


### PR DESCRIPTION
After changing the default shell with `babun shell <new_shell>` you need to run `babun shell-here init` again to change the context menu to the new shell.