### PR TITLE
fix for pact issue with packageof #335

### DIFF
--- a/babun-core/plugins/pact/src/pact
+++ b/babun-core/plugins/pact/src/pact
@@ -472,9 +472,9 @@ case "$command" in
       then
         key="$pkg"
       fi
-      for manifest in /etc/setup/*.lst.gz
+      for manifest in `find /etc/setup -type f -name '*\.lst\.gz'`
       do
-        found=`cat $manifest | gzip -d | grep -c "$key"`
+        found=`cat $manifest | gzip -d | if [ $(grep -c "$key") -gt 0 ]; then echo "1"; else echo "0"; fi`
         if test $found -gt 0
         then
           package=`echo $manifest | sed -e "s:/etc/setup/::" -e "s/.lst.gz//"`


### PR DESCRIPTION
1) globbing for some reason doesn't work ... so i replaced it with find
2) grep always return 1 as exit code if it doesn't find a pattern ... so the check_err function will always complain about errors even thou there are none ... i've added if statement wrapper to eliminate non-zero exit code
