### PR TITLE
bypass certificate checks

### DIFF
--- a/babun-dist/start/update.bat
+++ b/babun-dist/start/update.bat
@@ -66,10 +66,10 @@ echo [babun] Writing data to %DIST_DIR%
 
 "%BASH%" -c "source ~/.babunrc; /bin/rm.exe -f '%DIST_DIR%/setup-x86.exe' '%DIST_DIR%/cygwin.version'" || goto :ERROR
 echo download cyg version
-"%BASH%" -c "source ~/.babunrc; /bin/wget.exe --directory-prefix='%DIST_DIR%' https://raw.githubusercontent.com/babun/babun-cygwin/master/cygwin.version" || goto :ERROR
+"%BASH%" -c "source ~/.babunrc; /bin/wget.exe --no-check-certificate --directory-prefix='%DIST_DIR%' https://raw.githubusercontent.com/babun/babun-cygwin/master/cygwin.version" || goto :ERROR
 set /p CYGWIN_VERSION=<"%DIST_DIR%/cygwin.version"
 echo [babun] Downloading Cygwin %CYGWIN_VERSION%
-"%BASH%" -c "source ~/.babunrc; /bin/wget.exe --directory-prefix='%DIST_DIR%' https://raw.githubusercontent.com/babun/babun-cygwin/%CYGWIN_VERSION%/babun-cygwin/setup-x86.exe" || goto :ERROR
+"%BASH%" -c "source ~/.babunrc; /bin/wget.exe --no-check-certificate --directory-prefix='%DIST_DIR%' https://raw.githubusercontent.com/babun/babun-cygwin/%CYGWIN_VERSION%/babun-cygwin/setup-x86.exe" || goto :ERROR
 
 :SETUPRC
 echo [babun] Preparing setup.rc config


### PR DESCRIPTION
This fix will help out anybody who was experiencing `update.bat` fail due to certificate checks when stuck behind a firewall. 