### PR TITLE
Updated http://babun.github.io/ links to https

### DIFF
--- a/babun-doc/adoc/_faq.adoc
+++ b/babun-doc/adoc/_faq.adoc
@@ -33,7 +33,7 @@ Use the install.bat script and specify the /target option.
 
 == I cloned Babun from github but when i try to start it I get some weird error messages.
 
-You have to download the distribution package from http://babun.github.io.
+You have to download the distribution package from https://babun.github.io.
 On github we only host raw source files. The dist package is enriched by cygwin and some other stuff you need to be able to run Babun.
 
 == How can I uninstall Babun?

--- a/babun-doc/adoc/_installation.adoc
+++ b/babun-doc/adoc/_installation.adoc
@@ -2,7 +2,7 @@
 
 == Installation
 
-Just download the dist file from http://babun.github.io, unzip it and run the install.bat script. After a few minutes babun starts automatically.
+Just download the dist file from https://babun.github.io, unzip it and run the install.bat script. After a few minutes babun starts automatically.
 The application will be installed to the `%USERPROFILE%\.babun` directory. Use the '/target' option to install babun to a custom directory.
 
 NOTE: There is no interference with existing Cygwin installation


### PR DESCRIPTION
http://babun.github.io/ is 404'n so I updated the links to the https (https://babun.github.io/) version which appears to be online.