### PR TITLE
Bash sources profiles

### DIFF
--- a/babun-core/plugins/core/src/babun.bash
+++ b/babun-core/plugins/core/src/babun.bash
@@ -2,8 +2,6 @@
 # DO NOT MODIFY THIS FILE -> IT WILL BE OVERWRITTEN ON UPDATE
 # If you want to some options modify the following file: ~/.bashrc
 source /etc/profile
-test -f "$homedir/.profile" && source "$homedir/.profile"
-test -f "$homedir/.bash_profile" && source "$homedir/.bash_profile"
 source "/usr/local/etc/babun.instance"
 
 PS1="\[\033[00;34m\]{ \[\033[01;34m\]\W \[\033[00;34m\]}\[\033[01;32m\] \$( git rev-parse --abbrev-ref HEAD 2> /dev/null || echo "" ) \[\033[01;31m\]» \[\033[00m\]"


### PR DESCRIPTION
       The following paragraphs describe how bash executes its startup  files.   If  any  of  the
       files  exist  but cannot be read, bash reports an error.  Tildes are expanded in filenames
       as described below under Tilde Expansion in the EXPANSION section.

       When bash is invoked as an interactive login shell, or as a non-interactive shell with the
       --login  option,  it first reads and executes commands from the file /etc/profile, if that
       file exists.  After reading that file, it looks for  ~/.bash_profile,  ~/.bash_login,  and
       ~/.profile,  in that order, and reads and executes commands from the first one that exists
       and is readable.  The --noprofile option may be used when the shell is started to  inhibit
       this behavior.

