### PR TITLE
Check existence before creating link

### DIFF
--- a/babun-core/plugins/cygdrive/start.sh
+++ b/babun-core/plugins/cygdrive/start.sh
@@ -18,7 +18,7 @@ if ! [[ "$DISABLE_PLUGIN_CYGDRIVE" == "true" ]]; then
 	do
 		drive_name=$(basename $cygdrive_dir)
 
-		if [[ "$drive_name" != "cygdrive" ]]; then
+		if [[ "$drive_name" != "cygdrive" && ! -e "/$drive_name" ]]; then
 			ln -s "$cygdrive_dir" "/$drive_name"
 		fi
 	done


### PR DESCRIPTION
The script will fail if the user has already created a file or directory with the name of a drive. Check before creating the symbolic link.